### PR TITLE
CDE-86 : ajout d'un controle sur le provider dans les notices

### DIFF
--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/component/BaseXmlFunctionsCaller.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/component/BaseXmlFunctionsCaller.java
@@ -6,13 +6,15 @@ import org.springframework.jdbc.UncategorizedSQLException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import java.sql.SQLRecoverableException;
+
 @Component
 public class BaseXmlFunctionsCaller {
     @Autowired
     private JdbcTemplate baseXmlJdbcTemplate;
 
     @ColumnTransformer(read = "XMLSERIALIZE (CONTENT data_xml as CLOB)", write = "NULLSAFE_XMLTYPE(?)")
-    public String issnToPpn(String issn) throws UncategorizedSQLException {
+    public String issnToPpn(String issn) throws SQLRecoverableException, UncategorizedSQLException {
         StringBuilder request = new StringBuilder("SELECT AUTORITES.ISSN2PPNJSON('");
         request.append(issn);
         request.append("') as data_xml from DUAL");
@@ -20,7 +22,7 @@ public class BaseXmlFunctionsCaller {
     }
 
     @ColumnTransformer(read = "XMLSERIALIZE (CONTENT data_xml as CLOB)", write = "NULLSAFE_XMLTYPE(?)")
-    public String isbnToPpn(String isbn) throws UncategorizedSQLException {
+    public String isbnToPpn(String isbn) throws SQLRecoverableException, UncategorizedSQLException {
         StringBuilder request = new StringBuilder("SELECT AUTORITES.ISBN2PPNJSON('");
         request.append(isbn);
         request.append("') as data_xml from DUAL");

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/configuration/UtilsConfig.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/configuration/UtilsConfig.java
@@ -9,9 +9,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
-public class MapperConfig {
+public class UtilsConfig {
     @Bean
     public XmlMapper xmlMapper() {
         JacksonXmlModule module = new JacksonXmlModule();
@@ -33,5 +34,10 @@ public class MapperConfig {
         MappingJackson2HttpMessageConverter jsonConverter = new MappingJackson2HttpMessageConverter();
         jsonConverter.setObjectMapper(objectMapper());
         return jsonConverter;
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/controller/KbartController.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/controller/KbartController.java
@@ -7,6 +7,7 @@ import fr.abes.convergence.kbartws.exception.IllegalPpnException;
 import fr.abes.convergence.kbartws.service.IIdentifiantService;
 import fr.abes.convergence.kbartws.service.IdentifiantFactory;
 import fr.abes.convergence.kbartws.service.NoticeService;
+import fr.abes.convergence.kbartws.service.ProviderService;
 import fr.abes.convergence.kbartws.utils.TYPE_ID;
 import fr.abes.convergence.kbartws.utils.TYPE_SUPPORT;
 import fr.abes.convergence.kbartws.utils.Utilitaire;
@@ -14,9 +15,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestClientResponseException;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @CrossOrigin(origins = "*")
@@ -27,11 +30,15 @@ public class KbartController {
     private IdentifiantFactory factory;
 
     @Autowired
+    private ProviderService providerService;
+
+    @Autowired
     private NoticeService noticeService;
 
-    @GetMapping(value = "/online_identifier_2_ppn/{type}/{onlineIdentifier}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResultWsDto onlineIdentifier2Ppn(@PathVariable String type, @PathVariable String onlineIdentifier) throws IOException {
+    @GetMapping(value = {"/online_identifier_2_ppn/{type}/{onlineIdentifier}", "/online_identifier_2_ppn/{type}/{onlineIdentifier}/{provider}"}, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResultWsDto onlineIdentifier2Ppn(@PathVariable String type, @PathVariable String onlineIdentifier, @PathVariable(required = false) Optional<String> provider) throws IOException {
         ResultWsDto resultat = new ResultWsDto();
+        Optional<String> providerDisplayName = getProviderDisplayName(provider, resultat);
         try {
             TYPE_ID enumType = Utilitaire.getEnumFromString(type);
             IIdentifiantService service = factory.getService(enumType);
@@ -40,7 +47,7 @@ public class KbartController {
                         NoticeXml notice = noticeService.getNoticeByPpn(ppn);
                         if (!notice.isDeleted()) {
                             if (notice.isNoticeElectronique()) {
-                                resultat.addPpn(new PpnWithTypeWebDto(notice.getPpn(), notice.getTypeSupport()));
+                                checkProviderDansNoticeGeneral(provider, resultat, providerDisplayName, notice);
                             } else {
                                 resultat.addErreur("Le PPN " + notice.getPpn() + " n'est pas une ressource électronique");
                             }
@@ -61,11 +68,13 @@ public class KbartController {
         return resultat;
     }
 
-    @GetMapping(value = "/print_identifier_2_ppn/{type}/{printIdentifier}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResultWsDto printIdentifier2Ppn(@PathVariable String type, @PathVariable String printIdentifier) throws IOException {
+
+    @GetMapping(value = {"/print_identifier_2_ppn/{type}/{printIdentifier}","/print_identifier_2_ppn/{type}/{printIdentifier}/{provider}"}, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResultWsDto printIdentifier2Ppn(@PathVariable String type, @PathVariable String printIdentifier, @PathVariable Optional<String> provider) throws IOException {
+        ResultWsDto resultat = new ResultWsDto();
+        Optional<String> providerDisplayName = getProviderDisplayName(provider, resultat);
         try {
             TYPE_ID enumType = Utilitaire.getEnumFromString(type);
-            ResultWsDto resultat = new ResultWsDto();
             IIdentifiantService service = factory.getService(enumType);
             if (service.checkFormat(printIdentifier)) {
                 for (String ppn : service.getPpnFromIdentifiant(printIdentifier)) {
@@ -77,7 +86,11 @@ public class KbartController {
                                 //aucun ppn électronique trouvé dans une notice liée, on renvoie le ppn imprimé
                                 resultat.addPpn(new PpnWithTypeWebDto(ppn, TYPE_SUPPORT.IMPRIME));
                             } else {
-                                ppnElect.forEach(ppnLie -> resultat.addPpn(new PpnWithTypeWebDto(ppnLie, TYPE_SUPPORT.ELECTRONIQUE)));
+                                Optional<String> finalProviderDisplayName = providerDisplayName;
+                                for (String ppnLie : ppnElect) {
+                                    NoticeXml noticeLiee = noticeService.getNoticeByPpn(ppnLie);
+                                    checkProviderDansNoticeGeneral(provider, resultat, finalProviderDisplayName, noticeLiee);
+                                }
                             }
                         } else {
                             resultat.addErreur("Le PPN " + notice.getPpn() + " n'est pas une ressource imprimée");
@@ -94,5 +107,38 @@ public class KbartController {
             log.error("erreur dans la récupération de la notice correspondant à l'identifiant " + printIdentifier);
             throw new IOException(ex);
         }
+    }
+
+    private Optional<String> getProviderDisplayName(Optional<String> provider, ResultWsDto resultat) {
+        Optional<String> providerDisplayName = Optional.empty();
+        try {
+            providerDisplayName = (provider.isPresent()) ? providerService.getProviderDisplayName(provider.get()) : Optional.empty();
+        } catch (IOException | RestClientResponseException ex) {
+            log.error(ex.getMessage());
+            resultat.addErreur("Impossible d'analyser le provider en raison d'un problème technique, poursuite du traitement");
+        }
+        return providerDisplayName;
+    }
+    private void checkProviderDansNoticeGeneral(Optional<String> provider, ResultWsDto resultat, Optional<String> providerDisplayName, NoticeXml notice) {
+        if (providerDisplayName.isPresent() && provider.isPresent()) {
+            if (checkProviderDansNotice(providerDisplayName.get(), notice) || checkProviderDansNotice(provider.get(), notice))
+                resultat.addPpn(new PpnWithTypeWebDto(notice.getPpn(), notice.getTypeSupport()));
+            else
+                resultat.addErreur("PPN : " + notice.getPpn() + " ne contient pas le provider " + provider.get() + " en 035$a, 210$c ou 214$c");
+        }
+        else {
+            resultat.addPpn(new PpnWithTypeWebDto(notice.getPpn(), notice.getTypeSupport()));
+        }
+    }
+
+    private boolean checkProviderDansNotice(String provider, NoticeXml notice) {
+        String providerWithoutDiacritics = Utilitaire.replaceDiacritics(provider);
+        //TODO : le test sur la 035 sera finalement fait dans une US ultérieure, manque une information pour la comparaison
+        //if (!notice.checkProviderIn035a(providerWithoutDiacritics)) {
+        return notice.checkProviderInZone(providerWithoutDiacritics, "210", "c") || notice.checkProviderInZone(providerWithoutDiacritics, "214", "c");
+
+        //} else {
+        //    resultat.addPpn(new PpnWithTypeWebDto(notice.getPpn(), notice.getTypeSupport()));
+        //}
     }
 }

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/dto/provider/BaconDto.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/dto/provider/BaconDto.java
@@ -1,0 +1,14 @@
+package fr.abes.convergence.kbartws.dto.provider;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class BaconDto {
+    @JsonProperty("query")
+    private QueryDto query;
+}

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/dto/provider/ElementDto.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/dto/provider/ElementDto.java
@@ -1,0 +1,18 @@
+package fr.abes.convergence.kbartws.dto.provider;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class ElementDto {
+    @JsonProperty("provider")
+    private String provider;
+    @JsonProperty("display_name")
+    private String displayName;
+    @JsonProperty("idprovider")
+    private String idProvider;
+}

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/dto/provider/QueryDto.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/dto/provider/QueryDto.java
@@ -1,0 +1,16 @@
+package fr.abes.convergence.kbartws.dto.provider;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class QueryDto {
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("results")
+    private ResultDto[] results;
+}

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/dto/provider/ResultDto.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/dto/provider/ResultDto.java
@@ -1,0 +1,14 @@
+package fr.abes.convergence.kbartws.dto.provider;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class ResultDto {
+    @JsonProperty("element")
+    private ElementDto elements;
+}

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/dto/provider/ResultProviderDto.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/dto/provider/ResultProviderDto.java
@@ -1,0 +1,14 @@
+package fr.abes.convergence.kbartws.dto.provider;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@JsonRootName("bacon")
+public class ResultProviderDto {
+    private BaconDto bacon;
+}

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/entity/notice/NoticeXml.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/entity/notice/NoticeXml.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -93,5 +94,39 @@ public class NoticeXml {
             }
         }
         return ppns;
+    }
+
+    /**
+     * Méthode vérifiant si un provider est présent en début d'une 035 $a
+     * @param provider provider à vérifier
+     * @return true si le provider est présent en début d'une 035$a, false sinon
+     */
+    public boolean checkProviderIn035a(String provider) {
+        List<Datafield> listeZone = this.datafields.stream().filter(datafield -> datafield.getTag().equals("035")).collect(Collectors.toList());
+        if (!listeZone.isEmpty()) {
+            for (Datafield datafield : listeZone) {
+                List<SubField> subFields = datafield.getSubFields().stream().filter(subField -> subField.getCode().equals("a")).collect(Collectors.toList());
+                if (subFields.stream().anyMatch(sf -> sf.getValue().toLowerCase().startsWith(provider.toLowerCase()))) return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Méthode permettant de vérifier si un provider est contenu dans une zone
+     * @param provider : le provider à vérifier
+     * @param zone : la zone à chercher dans la notice
+     * @param sousZone : la sous zone à chercher dans la zone
+     * @return true si le provider est contenu dans la zone / sous zone passée en paramètre
+     */
+    public boolean checkProviderInZone(String provider, String zone, String sousZone) {
+        List<Datafield> listeZone = this.datafields.stream().filter(datafield -> datafield.getTag().equals(zone)).collect(Collectors.toList());
+        if (!listeZone.isEmpty()) {
+            for (Datafield datafield : listeZone) {
+                List<SubField> subFields = datafield.getSubFields().stream().filter(subField -> subField.getCode().equals(sousZone)).collect(Collectors.toList());
+                if (subFields.stream().anyMatch(sf -> sf.getValue().toLowerCase().contains(provider.toLowerCase(Locale.ROOT)))) return true;
+            }
+        }
+        return false;
     }
 }

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/exception/ExceptionControllerHandler.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/exception/ExceptionControllerHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.io.IOException;
+import java.net.ConnectException;
 
 @ControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -58,4 +59,5 @@ public class ExceptionControllerHandler extends ResponseEntityExceptionHandler {
         String error = "Erreur dans l'accès aux données";
         return buildResponseEntity(new ApiReturnError(HttpStatus.SERVICE_UNAVAILABLE, error, ex));
     }
+
 }

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/service/IsbnService.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/service/IsbnService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.sql.SQLRecoverableException;
 import java.util.List;
 
 @Service
@@ -34,6 +35,8 @@ public class IsbnService implements IIdentifiantService {
             throw new IllegalPpnException("Aucune notice ne correspond à la recherche");
         } catch (JsonProcessingException ex) {
             throw new IOException("Impossible de récupérer les ppns correspondant à cet identifiant");
+        } catch (SQLRecoverableException ex) {
+            throw new IOException("Incident technique lors de l'accès à la base de données");
         }
     }
 }

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/service/IssnService.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/service/IssnService.java
@@ -8,6 +8,7 @@ import org.springframework.jdbc.UncategorizedSQLException;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.sql.SQLRecoverableException;
 import java.util.List;
 
 @Service
@@ -31,6 +32,8 @@ public class IssnService implements IIdentifiantService {
             throw new IllegalPpnException("Aucune notice ne correspond à la recherche");
         } catch (JsonProcessingException ex) {
             throw new IOException("Impossible de récupérer les ppns correspondant à cet identifiant");
+        } catch (SQLRecoverableException ex) {
+            throw new IOException("Incident technique lors de l'accès à la base de données");
         }
     }
 

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/service/ProviderService.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/service/ProviderService.java
@@ -1,0 +1,20 @@
+package fr.abes.convergence.kbartws.service;
+
+import fr.abes.convergence.kbartws.dto.provider.ResultProviderDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ProviderService {
+    private final WsService wsService;
+
+    public Optional<String> getProviderDisplayName(String shortName) throws IOException {
+        ResultProviderDto result = wsService.callProviderList();
+        return Arrays.stream(result.getBacon().getQuery().getResults()).toList().stream().filter(el -> el.getElements().getProvider().equalsIgnoreCase(shortName)).map(res -> res.getElements().getDisplayName()).findFirst();
+    }
+}

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/service/WsService.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/service/WsService.java
@@ -1,0 +1,61 @@
+package fr.abes.convergence.kbartws.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fr.abes.convergence.kbartws.dto.provider.ResultDto;
+import fr.abes.convergence.kbartws.dto.provider.ResultProviderDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+
+@Service
+@Slf4j
+public class WsService {
+    @Value("${url.provider_list}")
+    private String providerList;
+
+    private final RestTemplate restTemplate;
+    private final HttpHeaders headers;
+
+    private final ObjectMapper mapper;
+
+    public WsService(ObjectMapper mapper, RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+        this.headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        this.mapper = mapper;
+    }
+
+
+    public String postCall(String url, String requestJson) {
+        HttpEntity<String> entity = new HttpEntity<>(requestJson, headers);
+
+        restTemplate.getMessageConverters()
+                .add(0, new StringHttpMessageConverter(StandardCharsets.UTF_8));
+        return restTemplate.postForObject(url, entity, String.class);
+    }
+
+    public String getCall(String url, String... params) {
+        StringBuilder formedUrl = new StringBuilder(url);
+        for (String param : params) {
+            formedUrl.append("/");
+            formedUrl.append(param);
+        }
+        log.debug(formedUrl.toString());
+        return restTemplate.getForObject(formedUrl.toString(), String.class);
+    }
+
+    public ResultProviderDto callProviderList() throws RestClientResponseException, JsonProcessingException {
+        String result = getCall(providerList);
+        return mapper.readValue(result, ResultProviderDto.class);
+    }
+
+}

--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/utils/Utilitaire.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/utils/Utilitaire.java
@@ -52,5 +52,28 @@ public class Utilitaire {
             }
         }
     }
+
+    /**
+     * Méthode permettant de remplacer les caractères diacritiques d'une chaine par leur équivalent non diacritique
+     * @param src chaine à transformer
+     * @return chaine transformée
+     */
+    public static String replaceDiacritics(String src) {
+        StringBuffer result = new StringBuffer();
+        if(src!=null && src.length()!=0) {
+            int index = -1;
+            char c;
+            String chars= "àâäéèêëîïôöùûüç";
+            String replace= "aaaeeeeiioouuuc";
+            for(int i=0; i<src.length(); i++) {
+                c = src.charAt(i);
+                if( (index=chars.indexOf(c))!=-1 )
+                    result.append(replace.charAt(index));
+                else
+                    result.append(c);
+            }
+        }
+        return result.toString();
+    }
 }
 

--- a/kbart-webservices/src/main/resources/application-dev.properties
+++ b/kbart-webservices/src/main/resources/application-dev.properties
@@ -9,3 +9,5 @@ spring.jpa.basexml.properties.hibernate.dialect=org.hibernate.dialect.OracleDial
 spring.jpa.basexml.hibernate.ddl-auto=none
 spring.jpa.basexml.database-platform=org.hibernate.dialect.OracleDialect
 spring.sql.basexml.init.mode=never
+
+url.provider_list=https://www-dev.sudoc.fr/services/generic/?servicekey=bacon_provider

--- a/kbart-webservices/src/main/resources/application-prod.properties
+++ b/kbart-webservices/src/main/resources/application-prod.properties
@@ -9,3 +9,5 @@ spring.jpa.basexml.properties.hibernate.dialect=org.hibernate.dialect.OracleDial
 spring.jpa.basexml.hibernate.ddl-auto=none
 spring.jpa.basexml.database-platform=org.hibernate.dialect.OracleDialect
 spring.sql.basexml.init.mode=never
+
+url.provider_list=https://www.sudoc.fr/services/generic/?servicekey=bacon_provider

--- a/kbart-webservices/src/main/resources/application-test.properties
+++ b/kbart-webservices/src/main/resources/application-test.properties
@@ -9,3 +9,5 @@ spring.jpa.basexml.properties.hibernate.dialect=org.hibernate.dialect.OracleDial
 spring.jpa.basexml.hibernate.ddl-auto=none
 spring.jpa.basexml.database-platform=org.hibernate.dialect.OracleDialect
 spring.sql.basexml.init.mode=never
+
+url.provider_list=https://www-test.sudoc.fr/services/generic/?servicekey=bacon_provider

--- a/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/entity/notice/NoticeXmlTest.java
+++ b/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/entity/notice/NoticeXmlTest.java
@@ -40,4 +40,142 @@ class NoticeXmlTest {
         notice.setDatafields(Lists.newArrayList(datafield));
         Assertions.assertTrue(notice.get4XXDollar0("452").isEmpty());
     }
+
+    @Test
+    void checkProviderIn035a() {
+        String provider = "CAIRN";
+        NoticeXml notice = new NoticeXml();
+        //cas 1 seule occurrence
+        Datafield datafield = new Datafield();
+        datafield.setTag("035");
+        SubField subField1 = new SubField();
+        subField1.setCode("a");
+        subField1.setValue("test");
+        datafield.setSubFields(Lists.newArrayList(subField1));
+        notice.setDatafields(Lists.newArrayList(datafield));
+
+        Assertions.assertFalse(notice.checkProviderIn035a(provider));
+
+        subField1.setValue("CAIRN123456");
+        Assertions.assertTrue(notice.checkProviderIn035a(provider));
+
+        subField1.setValue("123456CAIRN654987");
+        Assertions.assertFalse(notice.checkProviderIn035a(provider));
+
+        subField1.setCode("0");
+        Assertions.assertFalse(notice.checkProviderIn035a(provider));
+
+        datafield.setTag("200");
+        Assertions.assertFalse(notice.checkProviderIn035a(provider));
+    }
+
+    @Test
+    void checkProviderIn035aMultipleZone() {
+        String provider = "CAIRN";
+        NoticeXml notice = new NoticeXml();
+        Datafield datafield = new Datafield();
+        SubField subField1 = new SubField();
+        datafield.setTag("035");
+        subField1.setCode("a");
+        subField1.setValue("test");
+        datafield.setSubFields(Lists.newArrayList(subField1));
+
+        Datafield datafield1 = new Datafield();
+        datafield1.setTag("035");
+        SubField subField2 = new SubField();
+        subField2.setCode("a");
+        subField2.setValue("CAIRN");
+        datafield1.setSubFields(Lists.newArrayList(subField2));
+
+        notice.setDatafields(Lists.newArrayList(datafield, datafield1));
+        Assertions.assertTrue(notice.checkProviderIn035a(provider));
+    }
+
+    @Test
+    void checkProviderIn035aMultipleSousZone() {
+        String provider = "CAIRN";
+        NoticeXml notice = new NoticeXml();
+        Datafield datafield = new Datafield();
+        SubField subField1 = new SubField();
+        datafield.setTag("035");
+        subField1.setCode("a");
+        subField1.setValue("test");
+
+        SubField subField2 = new SubField();
+        subField2.setCode("a");
+        subField2.setValue("CAIRN");
+        datafield.setSubFields(Lists.newArrayList(subField1, subField2));
+
+        notice.setDatafields(Lists.newArrayList(datafield));
+        Assertions.assertTrue(notice.checkProviderIn035a(provider));
+    }
+
+    @Test
+    void checkProviderInZone() {
+        String provider = "CAIRN";
+        NoticeXml notice = new NoticeXml();
+        //cas 1 seule occurrence
+        Datafield datafield = new Datafield();
+        datafield.setTag("200");
+        SubField subField1 = new SubField();
+        subField1.setCode("c");
+        subField1.setValue("test");
+        datafield.setSubFields(Lists.newArrayList(subField1));
+        notice.setDatafields(Lists.newArrayList(datafield));
+
+        Assertions.assertFalse(notice.checkProviderInZone(provider, "200", "c"));
+
+        subField1.setValue("CAIRN123456");
+        Assertions.assertTrue(notice.checkProviderInZone(provider, "200", "c"));
+
+        subField1.setValue("123456CAIRN654987");
+        Assertions.assertTrue(notice.checkProviderInZone(provider, "200", "c"));
+
+        subField1.setCode("0");
+        Assertions.assertFalse(notice.checkProviderInZone(provider, "200", "c"));
+
+        datafield.setTag("215");
+        Assertions.assertFalse(notice.checkProviderInZone(provider, "200", "c"));
+    }
+
+    @Test
+    void checkProviderInZoneMultipleZone() {
+        String provider = "CAIRN";
+        NoticeXml notice = new NoticeXml();
+        Datafield datafield = new Datafield();
+        SubField subField1 = new SubField();
+        datafield.setTag("200");
+        subField1.setCode("c");
+        subField1.setValue("test");
+        datafield.setSubFields(Lists.newArrayList(subField1));
+
+        Datafield datafield1 = new Datafield();
+        datafield1.setTag("200");
+        SubField subField2 = new SubField();
+        subField2.setCode("c");
+        subField2.setValue("CAIRN");
+        datafield1.setSubFields(Lists.newArrayList(subField2));
+
+        notice.setDatafields(Lists.newArrayList(datafield, datafield1));
+        Assertions.assertTrue(notice.checkProviderInZone(provider, "200", "c"));
+    }
+
+    @Test
+    void checkProviderInZoneMultipleSousZone() {
+        String provider = "CAIRN";
+        NoticeXml notice = new NoticeXml();
+        Datafield datafield = new Datafield();
+        SubField subField1 = new SubField();
+        datafield.setTag("200");
+        subField1.setCode("c");
+        subField1.setValue("test");
+
+        SubField subField2 = new SubField();
+        subField2.setCode("c");
+        subField2.setValue("CAIRN");
+        datafield.setSubFields(Lists.newArrayList(subField1, subField2));
+
+        notice.setDatafields(Lists.newArrayList(datafield));
+        Assertions.assertTrue(notice.checkProviderInZone(provider, "200", "c"));
+    }
 }

--- a/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/service/IsbnServiceTest.java
+++ b/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/service/IsbnServiceTest.java
@@ -13,6 +13,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.UncategorizedSQLException;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.sql.SQLRecoverableException;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
@@ -96,7 +98,7 @@ class IsbnServiceTest {
 
     @Test
     @DisplayName("getPpnFromIdentifiant with UncategorizedSQLException")
-    void testgetPpnUncategorizedException() {
+    void testgetPpnUncategorizedException() throws SQLRecoverableException {
         Mockito.doThrow(UncategorizedSQLException.class).when(caller).isbnToPpn(Mockito.anyString());
         Assertions.assertThrows(IllegalPpnException.class, () -> isbnService.getPpnFromIdentifiant("1111111111"));
     }

--- a/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/service/IssnServiceTest.java
+++ b/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/service/IssnServiceTest.java
@@ -15,6 +15,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.UncategorizedSQLException;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.sql.SQLRecoverableException;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
@@ -95,7 +97,7 @@ class IssnServiceTest {
 
     @Test
     @DisplayName("getPpnFromIdentifiant with UncategorizedSQLException")
-    void testgetPpnUncategorizedException() {
+    void testgetPpnUncategorizedException() throws SQLRecoverableException {
         Mockito.doThrow(UncategorizedSQLException.class).when(caller).issnToPpn(Mockito.anyString());
         Assertions.assertThrows(IllegalPpnException.class, () -> issnService.getPpnFromIdentifiant("11111111"));
     }

--- a/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/service/NoticeServiceTest.java
+++ b/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/service/NoticeServiceTest.java
@@ -1,6 +1,6 @@
 package fr.abes.convergence.kbartws.service;
 
-import fr.abes.convergence.kbartws.configuration.MapperConfig;
+import fr.abes.convergence.kbartws.configuration.UtilsConfig;
 import fr.abes.convergence.kbartws.entity.BiblioTableFrbr4XX;
 import fr.abes.convergence.kbartws.entity.NoticesBibio;
 import fr.abes.convergence.kbartws.entity.notice.Datafield;
@@ -33,7 +33,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SpringBootTest(classes = {NoticeService.class, MapperConfig.class})
+@SpringBootTest(classes = {NoticeService.class, UtilsConfig.class})
 class NoticeServiceTest {
     @Autowired
     private NoticeService service;

--- a/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/service/WsServiceTest.java
+++ b/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/service/WsServiceTest.java
@@ -1,0 +1,89 @@
+package fr.abes.convergence.kbartws.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fr.abes.convergence.kbartws.dto.provider.BaconDto;
+import fr.abes.convergence.kbartws.dto.provider.QueryDto;
+import fr.abes.convergence.kbartws.dto.provider.ResultDto;
+import fr.abes.convergence.kbartws.dto.provider.ResultProviderDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@SpringBootTest(classes = {WsService.class, ObjectMapper.class, RestTemplate.class})
+public class WsServiceTest {
+    @Value("${url.provider_list}")
+    String urlProvider;
+
+    @Autowired
+    WsService wsService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    RestTemplate restTemplate;
+
+    @Test
+    void getCallTest() {
+        String url = "http://www.serviceTest.com/service/type/id";
+        Mockito.when(restTemplate.getForObject(url, String.class)).thenReturn("test");
+
+        Assertions.assertEquals("test", wsService.getCall("http://www.serviceTest.com/service", "type", "id"));
+    }
+
+    @Test
+    void postCallTest() {
+        String url = "http://www.serviceTest.com/service/";
+        StringBuilder json = new StringBuilder("{\n");
+        json.append("\"test\":\"test\"\n");
+        json.append("}");
+
+        Mockito.when(restTemplate.postForObject(Mockito.anyString(), Mockito.any(), Mockito.any())).thenReturn("test");
+
+        Assertions.assertEquals("test", wsService.postCall(url, json.toString()));
+    }
+
+    @Test
+    void callProviderList() throws JsonProcessingException {
+        StringBuilder json = new StringBuilder("{\n");
+        json.append("\"bacon\": {");
+        json.append("   \"query\": {");
+        json.append("       \"id\": \"list\",");
+        json.append("       \"results\": [");
+        json.append("           {");
+        json.append("               \"element\": {");
+        json.append("                   \"provider\": \"AAAS\",");
+        json.append("                   \"display_name\": \"American Association for the Advancement of Science\",");
+        json.append("                   \"idprovider\": 581");
+        json.append("               }");
+        json.append("           },");
+        json.append("           {");
+        json.append("               \"element\": {");
+        json.append("                   \"provider\": \"AACR\",");
+        json.append("                   \"display_name\": \"American Association for Cancer Research\",");
+        json.append("                   \"idprovider\": 523");
+        json.append("               }");
+        json.append("           }");
+        json.append("       ]");
+        json.append("   }");
+        json.append("}");
+        json.append("}");
+
+        Mockito.when(restTemplate.getForObject(urlProvider, String.class)).thenReturn(json.toString());
+
+        ResultProviderDto result = wsService.callProviderList();
+
+        Assertions.assertEquals(2, result.getBacon().getQuery().getResults().length);
+        Assertions.assertEquals("American Association for the Advancement of Science", result.getBacon().getQuery().getResults()[0].getElements().getDisplayName());
+        Assertions.assertEquals("American Association for Cancer Research", result.getBacon().getQuery().getResults()[1].getElements().getDisplayName());
+
+    }
+}

--- a/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/utils/UtilitaireTest.java
+++ b/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/utils/UtilitaireTest.java
@@ -79,4 +79,14 @@ class UtilitaireTest {
         Assertions.assertEquals("111111111", ppns.get(2));
         Assertions.assertEquals("222222222", ppns.get(3));
     }
+
+    @Test
+    @DisplayName("test replaceDiacritics")
+    void testReplaceDiacritics() {
+        String chaine = "àâäéèêëîïôöùûüç";
+        Assertions.assertEquals("aaaeeeeiioouuuc", Utilitaire.replaceDiacritics(chaine));
+
+        chaine = "çüûùöôïîëêèéäâà";
+        Assertions.assertEquals("cuuuooiieeeeaaa", Utilitaire.replaceDiacritics(chaine));
+    }
 }


### PR DESCRIPTION
Ajout WS Récupération de la liste des provider bacon Ajout paramètre dans controller
Ajout algorithme vérifiant la présence du provider dans certaines zones de la notice (210$c, 214$c) Ajout gestion d'exception en cas de problème d'accès au ws ou à la base de données Blindage de TU