### PR TITLE
FIX : CDE-352-cas-algo-score-6-nest-plus-pris-en-compte :

### DIFF
--- a/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/controller/KbartController.java
+++ b/kbart-webservices/src/main/java/fr/abes/convergence/kbartws/controller/KbartController.java
@@ -106,8 +106,12 @@ public class KbartController {
                                     checkProviderDansNoticeGeneral(resultat, providerDto, noticeLiee);
                                 }
                             }
-                        } else {
-                            resultat.addErreur("Le PPN " + notice.getPpn() + " n'est pas une ressource imprimée");
+                        } else if (notice.isNoticeElectronique()){
+                            boolean providerPresent = false;
+                            if (providerDto.isPresent()) {
+                                providerPresent = (checkProviderDansNotice(providerDto.get().getDisplayName(), notice) || checkProviderDansNotice(providerDto.get().getProvider(), notice) || checkProviderIn035(providerDto.get().getIdProvider(), notice));
+                            }
+                            resultat.addPpn(new PpnWithTypeWebDto(ppn, TYPE_SUPPORT.AUTRE, notice.getTypeDocument(), providerPresent));
                         }
                     }
                 }

--- a/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/controller/KbartControllerTest.java
+++ b/kbart-webservices/src/test/java/fr/abes/convergence/kbartws/controller/KbartControllerTest.java
@@ -474,10 +474,12 @@ class KbartControllerTest {
 
         this.mockMvc.perform(get("/v1/print_identifier_2_ppn/" + type + "/" + onlineIdentifier))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.ppns[0].ppn").value("123456000"))
-                .andExpect(jsonPath("$.ppns[0].providerPresent").value(false))
-                .andExpect(jsonPath("$.erreurs[0]").value("Le PPN " + ctrlPpn.getValue() + " n'est pas une ressource imprimée"));
-
+                .andExpect(jsonPath("$.ppns[1].ppn").value("123456000"))
+                .andExpect(jsonPath("$.ppns[1].providerPresent").value(false))
+                .andExpect(jsonPath("$.ppns[1].typeSupport").value("IMPRIME"))
+                .andExpect(jsonPath("$.ppns[0].ppn").value("123456789"))
+                .andExpect(jsonPath("$.ppns[0].typeSupport").value("AUTRE"))
+                .andExpect(jsonPath("$.ppns[0].providerPresent").value(false));
     }
 
     @Test


### PR DESCRIPTION
     - ajout d'un contrôle dans le ws printIdentifier2Ppn() dans KbartController.java
     - adaptation des TU